### PR TITLE
Feature/match interval

### DIFF
--- a/SwiftParsec.xcodeproj/project.pbxproj
+++ b/SwiftParsec.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -412,6 +413,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -433,6 +435,7 @@
 				INFOPLIST_FILE = SwiftParsec/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = daviddufresne.SwiftParsec;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -456,6 +459,7 @@
 				INFOPLIST_FILE = SwiftParsec/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = daviddufresne.SwiftParsec;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/SwiftParsec/Character.swift
+++ b/SwiftParsec/Character.swift
@@ -50,6 +50,19 @@ public extension ParsecType where Stream.Element == Character, Result == Charact
         
     }
     
+    /// Return a parser that succeeds if the current character is in the supplied interval of characters. It returns the parsed character.
+    ///
+    ///     let digit = StringParser.oneOf("0"..."9")
+    ///
+    /// - parameter interval: A `ClosedInterval` of possible characters to match.
+    /// - returns: A parser that succeeds if the current character is in the supplied interval of characters.
+    /// - SeeAlso: `GenericParser.satisfy(predicate: Character -> Bool) -> GenericParser`
+    public static func oneOf(interval: ClosedInterval<Character>) -> GenericParser<Stream, UserState, Result> {
+        
+        return satisfy(interval.contains)
+        
+    }
+    
     /// Return a parser that succeeds if the current character is _not_ in the supplied list of characters. It returns the parsed character.
     ///
     ///     let consonant = StringParser.noneOf("aeiou")


### PR DESCRIPTION
Adds a variant of oneOf() with a `ClosedInterval<Character>` argument, allowing code similar to the following: 

 ````
let alnum = 
        StringParser.oneOf("A"..."Z")
    <|> StringParser.oneOf("a"..."z") 
    <|> StringParser.oneOf("0"..."9")
````
