### PR TITLE
Added a notAhead combinator

### DIFF
--- a/SwiftParsec/GenericParser.swift
+++ b/SwiftParsec/GenericParser.swift
@@ -234,6 +234,21 @@ public final class GenericParser<Stream: StreamType, UserState, Result>: ParsecT
         
     }
     
+    /// A combinator that checks whether `self` is not ahead without consuming any input.
+    ///
+    /// - returns: A parser that parses without consuming any input.
+    public var notAhead: GenericParser<Stream, UserState, ()> {
+        return GenericParser<Stream, UserState, ()>(parse: { state in
+            let consumed = self.parse(state: state)
+
+            if case .Some(let reply) = consumed, .Ok = reply {
+                return .None(.Error(ParseError.unknownParseError(state.position)))
+            }
+
+            return .None(.Ok((), state, ParseError.unknownParseError(state.position)))
+        })
+    }
+
     /// The `many` combinator applies the parser `self` _zero_ or more times. It returns an array of the returned values of `self`.
     ///
     ///     let identifier = identifierStart >>- { char in

--- a/SwiftParsecTests/GenericParserTests.swift
+++ b/SwiftParsecTests/GenericParserTests.swift
@@ -172,6 +172,33 @@ class GenericParserTests: XCTestCase {
         
     }
     
+    func testNotAhead() {
+
+        let sample = "asdfg"
+
+        let string1 = StringParser.string("asc")
+        let string2 = String.init <^> StringParser.anyCharacter.many
+        let notAhead = string1.notAhead *> string2
+
+        // Test when not ahead.
+        let notMatching = ["asdfg"]
+        let shouldFailMessage = "GenericParser.notAhead should have failed."
+
+        testStringParserSuccess(notAhead, inputs: notMatching) { input, result in
+            XCTAssertEqual(sample, result, self.formatErrorMessage(shouldFailMessage, input: input, result: result))
+        }
+
+        let matching = ["ascasdfg", "asc"]
+        let errorMessage = "GenericParser.notAhead error."
+        testStringParserFailure(notAhead, inputs: matching) { input, result in
+            XCTFail(self.formatErrorMessage(errorMessage, input: input, result: result))
+
+        }
+
+
+    }
+
+
     func testMany() {
         
         let manyString = StringParser.string("asdf").many


### PR DESCRIPTION
We needed a combinator that checks whether something is *not* ahead. We tried to write the tests in the same way as the tests for `lookAhead`.