### PR TITLE
add same-type constraint to Stream protocol

### DIFF
--- a/Sources/SwiftParsec/Parsec.swift
+++ b/Sources/SwiftParsec/Parsec.swift
@@ -394,7 +394,7 @@ public extension Parsec where UserState == () {
 // Extension containing useful methods to run a parser.
 /// A `Stream` instance is responsible for maintaining the position of the
 /// parser's stream.
-public protocol Stream: Collection, ExpressibleByArrayLiteral {}
+public protocol Stream: Collection, ExpressibleByArrayLiteral where ArrayLiteralElement == Element {}
 
 extension String: Stream {
     


### PR DESCRIPTION
Without this extra constraint, the expression `[inputToken]` in Sources/SwiftParsec/GenericParser.swift wouldn't be treated handled a Stream.