### PR TITLE
Add support for `swift-tools-version:4.2`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:4.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 //  Package.swift
 //  SwiftParsec
@@ -11,6 +13,6 @@ import PackageDescription
 let package = Package(
     name: "SwiftParsec",
     targets: [
-        Target(name: "SwiftParsec"),
+        .target(name: "SwiftParsec"),
     ]
 )


### PR DESCRIPTION
Hi @davedufresne, great to see there's a real working library similar to Parsec available in Swift! Unfortunately, there's this warning when using it in projects with Swift 4.2:

> warning: PackageDescription API v3 is deprecated and will be removed in the future; used by package(s): SwiftParsec

This can be easily fixed with a few additions to `Package.swift`. Please let me know if anything needs to be changed in this PR to be merged.

Thanks!