### PR TITLE
Fix products missing in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,14 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftParsec",
+    products: [
+        // Products define the executables and libraries produced by a package, and
+        // make them visible to other packages.
+        .library(
+            name: "SwiftParsec",
+            targets: ["SwiftParsec"]
+        ),
+    ],
     targets: [
         .target(name: "SwiftParsec"),
     ]


### PR DESCRIPTION
Hi @davedufresne, sorry I missed an important config part in the new 4.2 format of Package.swift. Without any `products` property passed to `Package` the library itself is not visible to any users. This is fixed with explicit product added. Otherwise users of SwiftParsec get this error when pulling it with SwiftPM:
>error: product dependency 'SwiftParsec' not found